### PR TITLE
Add backstepping example using PyInduct

### DIFF
--- a/method_packages/pyinduct_backstepping_example/metadata.yml
+++ b/method_packages/pyinduct_backstepping_example/metadata.yml
@@ -1,0 +1,16 @@
+key:  GHUBE
+predecessor_key: ''
+type: method_package
+name: 'PyInduct backstepping example, shared functions'
+short_description: ""
+version: 0.1.0
+tag_list:
+    - ''
+creator: 'Stefan Ecklebe <stefan.ecklebe@tu-dresden.de>'
+editor_list:
+    - ''
+creation_date: '2021-09-17'
+external_references: ''
+notes: ''
+compatible_environment_list:
+    - ''

--- a/method_packages/pyinduct_backstepping_example/src/feedback.py
+++ b/method_packages/pyinduct_backstepping_example/src/feedback.py
@@ -1,0 +1,138 @@
+import numpy as np
+from scipy.integrate import quad
+from scipy.interpolate import interp1d
+from scipy.special import i1
+
+import pyinduct as pi
+from pyinduct.core import integrate_function
+
+from simulation import ModalApproximation, FEMApproximation
+
+
+class AnalyticBacksteppingController(pi.SimulationInput):
+    """
+    Implementation of the backstepping controller from example 4.1 in
+    [KristicEtAl08].
+    """
+    def __init__(self, spat_dom, orig_params, sym_system):
+        super().__init__("AnalyticBacksteppingControl")
+        self.dom = spat_dom
+        _, _, self.lamda, _, _ = orig_params
+        self.sym_sys = sym_system
+        self.k_sim = None
+        self._build_feedback()
+
+    def _bst_kernel(self, x, y):
+        arg = np.sqrt(self.lamda*(x**2 - y**2))
+        if np.isclose(arg, 0):
+            return -self.lamda * y / 2
+        k = -self.lamda * x * i1(arg)/arg
+        return k
+
+    def _build_feedback(self):
+        """ Approximate the analytic kernel with the simulation basis """
+        def _kernel_factory(frac):
+            def _kernel_func(y):
+                return self._bst_kernel(1, y) * frac(y)
+            return _kernel_func
+
+        sys_base = pi.get_base(self.sym_sys.base_lbl)
+        areas = [self.dom.bounds]
+        k_sys = np.atleast_2d([integrate_function(_kernel_factory(f), areas)[0]
+                               for f in sys_base])
+        if isinstance(self.sym_sys, ModalApproximation):
+            self.k_sim = k_sys
+        elif isinstance(self.sym_sys, FEMApproximation):
+            # manually compute feedback vector
+            self.k_sim = self.sym_sys.transform_feedback(k_sys, sys_base)
+        else:
+            raise NotImplementedError
+
+    def _calc_output(self, **kwargs):
+        sim_weights = kwargs["weights"]
+        u = self.k_sim @ sim_weights
+        return dict(output=u)
+
+
+class ApproximatedBacksteppingController(pi.SimulationInput):
+
+    idx = 0
+
+    def __init__(self, orig_params, tar_params, n_modal, spatial_domain,
+                 sym_system, be_verbose=False):
+        super().__init__("ApproximatedBacksteppingController")
+        ApproximatedBacksteppingController.idx += 1
+        self.orig_base_lbl = "orig_eigen_vectors_{}".format(self.idx)
+        self.tar_base_lbl = "tar_eigen_vectors_{}".format(self.idx)
+        self.sym_sys = sym_system
+        self.verbose = be_verbose
+        self.k_sim = None
+
+        self._build_bases(n_modal, orig_params, tar_params, spatial_domain)
+        self._build_feedback()
+
+    def _build_feedback(self):
+        # weak form of the controller
+        orig_x = pi.FieldVariable(self.orig_base_lbl)
+        tar_x = pi.FieldVariable(self.tar_base_lbl,
+                                 weight_label=self.orig_base_lbl)
+        cont_weak_form = pi.WeakFormulation([
+            pi.ScalarTerm(orig_x(1)),
+            pi.ScalarTerm(tar_x(1), scale=-1)],
+            name="feedback_law")
+        # create implementation that fits the simulated system
+        if isinstance(self.sym_sys, ModalApproximation):
+            # simply use pyinduct feedback framework
+            self.approx_cont = pi.StateFeedback(cont_weak_form)
+        elif isinstance(self.sym_sys, FEMApproximation):
+            # manually compute feedback vector
+            ce = pi.parse_weak_formulation(cont_weak_form, finalize=False)
+            k_mod = ce.dynamic_forms[self.orig_base_lbl].matrices["E"][0][1]
+            modal_base = pi.get_base(self.orig_base_lbl)
+            self.k_sim = self.sym_sys.transform_feedback(k_mod, modal_base)
+        else:
+            raise NotImplementedError
+
+    def _build_bases(self, n_modal, orig_params, tar_params, spatial_domain):
+        """
+        Compute approximation bases for original and target system
+        """
+        # eigenvalues and -vectors of the original system
+        orig_eig_values, orig_eig_vectors = \
+            pi.SecondOrderDirichletEigenfunction.cure_interval(spatial_domain,
+                                                               param=orig_params,
+                                                               n=n_modal)
+        norm_orig_eig_vectors = pi.normalize_base(orig_eig_vectors)
+        pi.register_base(self.orig_base_lbl, norm_orig_eig_vectors)
+
+        # eigenvectors of the target system (slightly different)
+        target_eig_freq = pi.SecondOrderDirichletEigenfunction.eigval_tf_eigfreq(
+            tar_params, eig_val=orig_eig_values)
+        orig_scale = np.array(
+            [vec(0) for vec in norm_orig_eig_vectors.derive(1)])
+        tar_scale = orig_scale / target_eig_freq
+        _, tar_eig_vectors = pi.SecondOrderDirichletEigenfunction.cure_interval(
+            spatial_domain,
+            param=tar_params,
+            eig_val=orig_eig_values,
+            scale=tar_scale)
+        pi.register_base(self.tar_base_lbl, tar_eig_vectors)
+        if self.verbose:
+            pi.visualize_functions(orig_eig_vectors)
+            pi.visualize_functions(norm_orig_eig_vectors)
+            pi.visualize_functions(tar_eig_vectors)
+
+    def _calc_output(self, **kwargs):
+        if isinstance(self.sym_sys, ModalApproximation):
+            u = self.approx_cont(**kwargs)
+        elif isinstance(self.sym_sys, FEMApproximation):
+            sim_weights = kwargs["weights"]
+            u = self.k_sim @ sim_weights
+        else:
+            raise NotImplementedError
+        return dict(output=u)
+
+    def __del__(self):
+        pi.deregister_base(self.orig_base_lbl)
+        pi.deregister_base(self.tar_base_lbl)
+        ApproximatedBacksteppingController.idx -= 1

--- a/method_packages/pyinduct_backstepping_example/src/simulation.py
+++ b/method_packages/pyinduct_backstepping_example/src/simulation.py
@@ -1,0 +1,197 @@
+from abc import abstractmethod
+import numpy as np
+
+import pyinduct as pi
+
+
+class ApproximatedSystem:
+    @abstractmethod
+    def get_system(self, u):
+        pass
+
+    @abstractmethod
+    def get_initial_state(self, initial_profile, u):
+        pass
+
+    @abstractmethod
+    def get_results(self, weights, u, temp_dom, spat_dom, name=None):
+        pass
+
+
+class ModalApproximation(ApproximatedSystem):
+    """
+    Build a simulation model using modal transformation
+    """
+    def __init__(self, params, n_modal, spat_dom):
+        a2 = params[0]
+        z_start, z_end = spat_dom.bounds
+        self.base_lbl = "eigen_vectors"
+
+        # eigenvalues and -vectors of the system system
+        eig_values, eig_vectors = \
+            pi.SecondOrderDirichletEigenfunction.cure_interval(spat_dom,
+                                                               param=params,
+                                                               n=n_modal)
+        # pi.visualize_functions(orig_eig_vectors)
+        norm_eig_vectors = pi.normalize_base(eig_vectors)
+        # pi.visualize_functions(normalized_eig_vectors)
+        pi.register_base(self.base_lbl, norm_eig_vectors)
+
+        self.a_mat = np.diag(np.real_if_close(eig_values))
+        b_mat = -a2 * np.array([eig_vect.derive()(z_end)
+                                for eig_vect in norm_eig_vectors])
+        self.b_mat = np.reshape(b_mat, (b_mat.size, 1))
+
+    def get_system(self, u):
+        sys = pi.StateSpace(self.a_mat,
+                            self.b_mat,
+                            base_lbl=self.base_lbl,
+                            input_handle=u)
+        return sys
+
+    def get_initial_state(self, initial_profile, u):
+        eig_vectors = pi.get_base(self.base_lbl)
+        initial_weights = pi.project_on_base(initial_profile, eig_vectors)
+        return initial_weights
+
+    def get_results(self, weights, u, temp_dom, spat_dom, name=None):
+        ed = pi.evaluate_approximation(self.base_lbl,
+                                       weights,
+                                       temp_dom,
+                                       spat_dom,
+                                       name="x(z,t)" + name)
+        return ed
+
+    def __del__(self):
+        pi.deregister_base(self.base_lbl)
+
+
+class FEMApproximation:
+    def __init__(self, params, n_fem, spat_bounds):
+        self.params = params
+        self.approx_cnt = n_fem
+        self.bounds = spat_bounds
+
+        self.base_lbl = "fem_base"
+        self.a_bar = None
+        self.a_tilde = None
+        self.a_tilde_inv = None
+        self.b_bar = None
+        self.b1 = None
+        self._build_system()
+
+    def _build_system(self):
+        # initial and test functions
+        nodes = pi.Domain(self.bounds, num=self.approx_cnt)
+        full_fem_base = pi.LagrangeFirstOrder.cure_interval(nodes)
+        act_fem_base = pi.Base(full_fem_base[-1])
+        not_act_fem_base = pi.Base(full_fem_base[1:-1])
+        pi.register_base("act_base", act_fem_base)
+        pi.register_base("sim_base", not_act_fem_base)
+        pi.register_base(self.base_lbl, full_fem_base)
+
+        a2, a1, a0, _, _ = self.params
+
+        # weak form
+        x = pi.FieldVariable("sim_base")
+        x_dt = x.derive(temp_order=1)
+        x_dz = x.derive(spat_order=1)
+        phi = pi.TestFunction("sim_base")
+        phi_dz = phi.derive(1)
+        act_phi = pi.ScalarFunction("act_base")
+        act_phi_dz = act_phi.derive(1)
+        u = pi.ConstantTrajectory(0)  # dummy input
+
+        weak_form = pi.WeakFormulation([
+            # ... of the homogeneous part of the system
+            pi.IntegralTerm(pi.Product(x_dt, phi),
+                            limits=self.bounds),
+            pi.IntegralTerm(pi.Product(x_dz, phi_dz),
+                            limits=self.bounds,
+                            scale=a2),
+            pi.IntegralTerm(pi.Product(x_dz, phi),
+                            limits=self.bounds,
+                            scale=-a1),
+            pi.IntegralTerm(pi.Product(x, phi),
+                            limits=self.bounds,
+                            scale=-a0),
+
+            # ... of the inhomogeneous part of the system
+            pi.IntegralTerm(pi.Product(pi.Product(act_phi, phi),
+                                       pi.Input(u, order=1)),
+                            limits=self.bounds),
+            pi.IntegralTerm(pi.Product(pi.Product(act_phi_dz, phi_dz),
+                                       pi.Input(u)),
+                            limits=self.bounds,
+                            scale=a2),
+            pi.IntegralTerm(pi.Product(pi.Product(act_phi_dz, phi),
+                                       pi.Input(u)),
+                            limits=self.bounds,
+                            scale=-a1),
+            pi.IntegralTerm(pi.Product(pi.Product(act_phi, phi),
+                                       pi.Input(u)),
+                            limits=self.bounds,
+                            scale=-a0)],
+            name="main_system")
+
+        # system matrices \dot x = A x + b0 u + b1 \dot u
+        cf = pi.parse_weak_formulation(weak_form)
+        ss = pi.create_state_space(cf)
+
+        a_mat = ss.A[1]
+        b0 = ss.B[0][1]
+        self.b1 = ss.B[1][1]
+
+        # Idea: \bar x = \tilde A x + b1 u
+        self.a_tilde = np.diag(np.ones(a_mat.shape[0]), 0)
+        self.a_tilde_inv = np.linalg.inv(self.a_tilde)
+
+        # Yields: \dot \bar x = \bar A \bar x + \bar b u
+        self.a_bar = (self.a_tilde @ a_mat) @ self.a_tilde_inv
+        self.b_bar = self.a_tilde @ (a_mat @ self.b1) + b0
+
+    def get_system(self, u):
+        ss = pi.StateSpace(self.a_bar, self.b_bar,
+                           base_lbl="transformed_base", input_handle=u)
+        return ss
+
+    def get_initial_state(self, initial_profile, u):
+        full_initial_state = pi.project_on_base(initial_profile,
+                                                pi.get_base(self.base_lbl))
+        hom_initial_state = full_initial_state[1:-1]
+        u0 = u(time=0, weights=hom_initial_state, weight_lbl=self.base_lbl)
+        bar_initial_state = (self.a_tilde @ hom_initial_state
+                             - (self.b1 * u0).flatten())
+        return bar_initial_state
+
+    def transform_feedback(self, k_src, src_base):
+        """ Transform the given feedback to work with the simulated system """
+        fem_base = pi.get_base(self.base_lbl)
+        t_fem_mod = pi.calculate_base_transformation_matrix(fem_base,
+                                                            src_base)
+        # in the following, we set \tilde A = I
+        k_fem = k_src @ t_fem_mod
+        k_inhom_0 = k_fem[:, 0]
+        k_hom = k_fem[:, 1:-1]
+        k_inhom_1 = k_fem[:, -1]
+        k_sim = - (k_hom + k_inhom_0 * 0) / (k_hom @ self.b1
+                                             + k_inhom_1 - 1)
+        return k_sim
+
+    def get_results(self, weights, u, temp_dom, spat_dom, name=None):
+        # back transformation
+        u_vec = u.get_results(temp_dom)
+        # if u_vec.dim == 1:
+        #     u_vec = u_vec[:, None]
+        orig_weights = weights @ self.a_tilde_inv + u_vec @ self.b1.T
+
+        # add missing values from dirichlet bc
+        all_weights = np.hstack((np.zeros_like(u_vec), orig_weights, u_vec))
+
+        # evaluate
+        ed = pi.evaluate_approximation("fem_base",
+                                       all_weights,
+                                       temp_dom,
+                                       spat_dom,
+                                       name="x(z,t)" + name)
+        return ed

--- a/problem_solutions/pyinduct_backstepping_example/metadata.yml
+++ b/problem_solutions/pyinduct_backstepping_example/metadata.yml
@@ -1,0 +1,21 @@
+key: HOZEE
+predecessor_key: ''
+type: problem_solution
+name: 'PyInduct backstepping example'
+short_description: 'An introductory backstepping example implemented using PyInduct'
+version: 0.1.0
+tag_list: []
+creator: 'Stefan Ecklebe <stefan.ecklebe@tu-dresden.de>'
+editor_list:
+    - ''
+creation_date: '2021-09-17'
+external_references: ''
+notes: ''
+solved_problem_list:
+    - KCZUI
+method_package_list:
+    - GHUBE
+compatible_environment: ''
+estimated_runtime: '10s'
+solution_file: solution.py
+postprocessing_file: ''

--- a/problem_solutions/pyinduct_backstepping_example/solution.py
+++ b/problem_solutions/pyinduct_backstepping_example/solution.py
@@ -1,0 +1,47 @@
+"""
+Ackrep solution file for backstepping-based control of an unstable heat equation
+"""
+from problem import ProblemSpecification
+from feedback import (AnalyticBacksteppingController,
+                      ApproximatedBacksteppingController)
+
+
+class SolutionData:
+    pass
+
+
+def solve(problem_spec: ProblemSpecification):
+    # get values from spec
+    spatial_domain = problem_spec.spatial_domain
+    orig_params = problem_spec.orig_params
+    fem_sys = problem_spec.fem_sys
+    modal_sys = problem_spec.modal_sys
+    n_modal = problem_spec.n_modal_sim
+
+    # target system parameters (controller parameters)
+    # Note: Backstepping is not able to alter a1 or a2!
+    a0_t = 0
+    tar_params = [problem_spec.a2, problem_spec.a1, a0_t, None, None]
+
+    # define analytic backstepping controller
+    analytic_cont = AnalyticBacksteppingController(spatial_domain,
+                                                   orig_params,
+                                                   fem_sys)
+
+    # define approximated backstepping controllers
+    approx_cont_mod = ApproximatedBacksteppingController(orig_params,
+                                                         tar_params,
+                                                         n_modal,
+                                                         spatial_domain,
+                                                         modal_sys)
+    approx_cont_fem = ApproximatedBacksteppingController(orig_params,
+                                                         tar_params,
+                                                         n_modal,
+                                                         spatial_domain,
+                                                         fem_sys)
+    sol_data = SolutionData()
+    sol_data.u = analytic_cont
+    # sol_data.u = approx_cont_fem
+    # sol_data.u = approx_cont_mod
+
+    return sol_data

--- a/problem_specifications/pyinduct_backstepping_example/metadata.yml
+++ b/problem_specifications/pyinduct_backstepping_example/metadata.yml
@@ -1,0 +1,16 @@
+key: KCZUI
+predecessor_key: ''
+type: problem_specification
+name: 'PyInduct backstepping example'
+short_description: 'An introductory backstepping example implemented using PyInduct'
+version: 0.1.0
+tag_list: []
+creator: 'Stefan Ecklebe <stefan.ecklebe@tu-dresden.de>'
+editor_list:
+    - ''
+creation_date: '2021-09-17'
+external_references: ''
+notes: ''
+problemclass_list:
+    - ''
+problem_file: problem.py

--- a/problem_specifications/pyinduct_backstepping_example/problem.py
+++ b/problem_specifications/pyinduct_backstepping_example/problem.py
@@ -1,0 +1,64 @@
+"""
+Problem file for ackrep framework
+"""
+import numpy as np
+import pyinduct as pi
+from ackrep_core import ResultContainer
+from matplotlib import pyplot as plt
+
+from simulation import FEMApproximation, ModalApproximation
+
+
+class ProblemSpecification:
+    """
+    Stabilization of an unstable heat equation of the form
+
+    x_dt = a2 x_ddz + a1 x_dz + a0 x
+
+    """
+    # original system parameters
+    a2 = 1
+    a1 = 0
+    a0 = 20
+    orig_params = [a2, a1, a0, None, None]
+
+    # system/simulation parameters
+    z_start = 0
+    z_end = 1
+    spat_bounds = (z_start, z_end)
+    spatial_domain = pi.Domain(bounds=spat_bounds, num=100)
+    temp_domain = pi.Domain(bounds=(0, .5), num=100)
+
+    # derive initial profile
+    np.random.seed(20210714)
+    initial_data = np.random.rand(*spatial_domain.shape)
+    initial_profile = pi.Function.from_data(spatial_domain,
+                                            initial_data,
+                                            domain=spat_bounds)
+
+    # number of basis functions, used for system approximation
+    n_fem_sim = 20
+    n_modal_sim = 10
+
+    # scenarios to simulate
+    fem_sys = FEMApproximation(orig_params, n_fem_sim, spat_bounds)
+    modal_sys = ModalApproximation(orig_params, n_modal_sim, spatial_domain)
+
+def evaluate_solution(solution_data):
+    sys = ProblemSpecification.fem_sys.get_system(solution_data.u)
+    ics = ProblemSpecification.fem_sys.get_initial_state(ProblemSpecification.initial_profile,
+                                            solution_data.u)
+    t_sim, q_sim = pi.simulate_state_space(sys, ics, ProblemSpecification.temp_domain)
+    x_sim = ProblemSpecification.fem_sys.get_results(q_sim,
+                                        solution_data.u,
+                                        t_sim,
+                                        ProblemSpecification.spatial_domain,
+                                        "FEM Simulation")
+    u_sim = solution_data.u.get_results(t_sim)
+
+    # check the solution
+    norm_at_end = np.sum(x_sim.output_data[-1]**2)
+    suc = np.isclose(norm_at_end, 0, atol=1e-5)
+    rc = ResultContainer(success=suc)
+
+    return rc


### PR DESCRIPTION
Add backstepping example for PDE system using PyInduct. Requires PyInduct to be installed globally on the ackrep instance.